### PR TITLE
allow setting LIBCLANG_PATH in environment on Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ be written to ``stdout``, or to a filename provided via the ``-o`` parameter.
 python -m pybind11_mkdoc -o docstrings.h header_file_1.h header_file_2.h
 ```
 
+Optionally, the path to the `libclang.so` can be specified by setting the LIBCLANG_PATH environment variable.
+
 Suppose we provide an input file with the following contents:
 
 ```cpp

--- a/pybind11_mkdoc/mkdoc_lib.py
+++ b/pybind11_mkdoc/mkdoc_lib.py
@@ -265,8 +265,11 @@ def read_args(args):
         # versions and distributions. LLVM switched to a monolithical setup
         # that includes everything under /usr/lib/llvm{version_number}/
         # We therefore glob for the library and select the highest version
-        library_file = sorted(glob("/usr/lib/llvm-*/lib/libclang.so.1"), reverse=True)[0]
-        cindex.Config.set_library_file(library_file)
+        if 'LIBCLANG_PATH' in os.environ:
+            cindex.Config.set_library_file(os.environ['LIBCLANG_PATH'])
+        else:
+            library_file = sorted(glob("/usr/lib/llvm-*/lib/libclang.so.1"), reverse=True)[0]
+            cindex.Config.set_library_file(library_file)
 
         # clang doesn't find its own base includes by default on Linux,
         # but different distros install them in different paths.


### PR DESCRIPTION
* useful if using the LLVM releases from tar files