### PR TITLE
Parsing and usage improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ be written to ``stdout``, or to a filename provided via the ``-o`` parameter.
 python -m pybind11_mkdoc -o docstrings.h header_file_1.h header_file_2.h
 ```
 
-Optionally, the path to the `libclang.so` can be specified by setting the LIBCLANG_PATH environment variable.
+Optionally, the path to the `libclang.so` and LLVM directory can be specified by setting the LIBCLANG_PATH and LLVM_DIR_PATH environment variables respectively.
 
 Suppose we provide an input file with the following contents:
 

--- a/pybind11_mkdoc/__main__.py
+++ b/pybind11_mkdoc/__main__.py
@@ -6,6 +6,7 @@ if __name__ == "__main__":
     mkdoc_out = None
     mkdoc_help = False
     mkdoc_args = []
+    docstring_width = None
 
     i = 1
     while i < len(sys.argv):
@@ -18,6 +19,11 @@ if __name__ == "__main__":
             i += 1 # Skip next
         elif arg.startswith('-o'):
             mkdoc_out = arg[2:]
+        elif arg == '-w':
+            docstring_width = int(sys.argv[i + 1])
+            i += 1 # Skip next
+        elif arg.startswith('-w'):
+            docstring_width = int(arg[2:])
         elif arg == '-I':
             # Concatenate include directive and path
             mkdoc_args.append(arg + sys.argv[i + 1])
@@ -38,10 +44,12 @@ Options:
 
   -o <filename>     Write to the specified filename (default: use stdout)
 
+  -w <width>        Specify docstring width before wrapping
+
   -I <path>         Specify an include directory
 
   -Dkey=value       Specify a compiler definition
 
 (Other compiler flags that Clang understands can also be supplied)""")
     else:
-        mkdoc(mkdoc_args, mkdoc_out)
+        mkdoc(mkdoc_args, docstring_width, mkdoc_out)

--- a/pybind11_mkdoc/mkdoc_lib.py
+++ b/pybind11_mkdoc/mkdoc_lib.py
@@ -278,12 +278,17 @@ def read_args(args):
         def folder_version(d):
             return [int(ver) for ver in re.findall(r'(?<!lib)(?<!\d)\d+', d)]
 
-        llvm_dir = max((
-            path
-            for libdir in ['lib64', 'lib', 'lib32']
-            for path in glob('/usr/%s/llvm-*' % libdir)
-            if os.path.isdir(path)
-        ), default=None, key=folder_version)
+        # capability to specify path to LLVM dir manually
+        # useful when installing LLVM to non standard directories
+        if 'LLVM_DIR_PATH' in os.environ:
+            llvm_dir = os.environ['LLVM_DIR_PATH']
+        else: 
+            llvm_dir = max((
+                path
+                for libdir in ['lib64', 'lib', 'lib32']
+                for path in glob('/usr/%s/llvm-*' % libdir)
+                if os.path.isdir(path)
+            ), default=None, key=folder_version)
 
 
         if llvm_dir:

--- a/pybind11_mkdoc/mkdoc_lib.py
+++ b/pybind11_mkdoc/mkdoc_lib.py
@@ -124,17 +124,18 @@ def process_comment(comment):
                r'\n\n$Template parameter ``\2``:\n\n', s)
 
     for in_, out_ in {
+        'returns': 'Returns',
         'return': 'Returns',
-        'author': 'Author',
         'authors': 'Authors',
+        'author': 'Author',
         'copyright': 'Copyright',
         'date': 'Date',
         'remark': 'Remark',
         'sa': 'See also',
         'see': 'See also',
         'extends': 'Extends',
-        'throw': 'Throws',
-        'throws': 'Throws'
+        'throws': 'Throws',
+        'throw': 'Throws'
     }.items():
         s = re.sub(r'[\\@]%s\s*' % in_, r'\n\n$%s:\n\n' % out_, s)
 

--- a/pybind11_mkdoc/mkdoc_lib.py
+++ b/pybind11_mkdoc/mkdoc_lib.py
@@ -62,6 +62,7 @@ CPP_OPERATORS = OrderedDict(
 job_count = cpu_count()
 job_semaphore = Semaphore(job_count)
 errors_detected = False
+docstring_width = int(70)
 
 
 class NoFilenamesError(ValueError):
@@ -165,7 +166,7 @@ def process_comment(comment):
     wrapper.expand_tabs = True
     wrapper.replace_whitespace = True
     wrapper.drop_whitespace = True
-    wrapper.width = 70
+    wrapper.width = docstring_width
     wrapper.initial_indent = wrapper.subsequent_indent = ''
 
     result = ''
@@ -376,7 +377,10 @@ def write_header(comments, out_file=sys.stdout):
 ''', file=out_file)
 
 
-def mkdoc(args, output=None):
+def mkdoc(args, width, output=None):
+    if width != None:
+        global docstring_width
+        docstring_width = int(width)
     comments = extract_all(args)
     if errors_detected:
         return


### PR DESCRIPTION
This PR adds a couple of improvements
 - Added @returns
 - Fixed @authors and @throws parsing.
 - Added a way to specify LLVM_DIR_PATH directory using environmental variable along LIBCLANG_PATH.
 - Added capability to specify docstring width before wrapping with parameter `-w [width]`