### PR TITLE
Changed the math format to use the reST math role

### DIFF
--- a/pybind11_mkdoc/mkdoc_lib.py
+++ b/pybind11_mkdoc/mkdoc_lib.py
@@ -153,7 +153,7 @@ def process_comment(comment):
     s = re.sub(r'<pre>(.*?)</pre>', r"```\n\1\n```\n", s, flags=re.DOTALL)
     s = re.sub(r'<em>(.*?)</em>', r'*\1*', s, flags=re.DOTALL)
     s = re.sub(r'<b>(.*?)</b>', r'**\1**', s, flags=re.DOTALL)
-    s = re.sub(r'[\\@]f\$(.*?)[\\@]f\$', r'$\1$', s, flags=re.DOTALL)
+    s = re.sub(r'[\\@]f\$(.*?)[\\@]f\$', r':math:`\1`', s, flags=re.DOTALL)
     s = re.sub(r'<li>', r'\n\n* ', s)
     s = re.sub(r'</?ul>', r'', s)
     s = re.sub(r'</li>', r'\n\n', s)


### PR DESCRIPTION
This PR changes the conversion of math formulas from "$formula$" to ":math:`formula`" to follow the [reST format](https://docutils.sourceforge.io/docs/ref/rst/roles.html#math).

This enables formulas to be correctly displayed with tools such as Sphinx

