### PR TITLE
Testing documentation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,11 +33,14 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
 
+    - name: Install dependencies
+      run: python -m pip install pytest-xdist
+
     - name: Install package
       run: python -m pip install .[test]
 
     - name: Test package
-      run: python -m pytest
+      run: python -m pytest --forked
 
 
 

--- a/README.md
+++ b/README.md
@@ -78,3 +78,21 @@ py::class_<MyClass>(m, "MyClass", DOC(MyClass))
 
 This tool supports Linux and macOS and requires Clang/LLVM to be installed. It
 has never been used on Windows and will likely require adaptations.
+
+
+## Testing
+
+Install package `pytest-xdist`:
+```
+python3 -m pip install pytest-xdist
+```
+
+Install the library:
+```
+python3 -m pip install .
+```
+
+And execute the tests (forked)
+```
+python3 -m pip pytest --forked
+```

--- a/tests/long_parameter_docs/long_parameter.h
+++ b/tests/long_parameter_docs/long_parameter.h
@@ -1,0 +1,5 @@
+/**
+ * Senectus et netus et malesuada fames ac. Tincidunt lobortis feugiat vivamus at augue eget arcu dictum varius.
+ * @param x - Begin first parameter description. Senectus et netus et malesuada fames ac. End first parameter description.
+ */
+void longParameterDescription(int x);

--- a/tests/long_parameter_test.py
+++ b/tests/long_parameter_test.py
@@ -1,0 +1,26 @@
+import collections
+import os
+import time
+import sysconfig
+import sys
+
+import pytest
+
+import pybind11_mkdoc
+
+DIR = os.path.abspath(os.path.dirname(__file__))
+
+def test_long_parameter(capsys):
+    comments = pybind11_mkdoc.mkdoc_lib.extract_all([os.path.join(DIR, "long_parameter_docs", "long_parameter.h")])
+    pybind11_mkdoc.mkdoc_lib.write_header(comments, sys.stdout)
+
+    res = capsys.readouterr()
+    expected = """\
+Parameter ``x``:
+    - Begin first parameter description. Senectus et netus et
+    malesuada fames ac. End first parameter description.)doc";
+"""
+
+    print(res.out)
+    assert expected in res.out
+

--- a/tests/sample_header_test.py
+++ b/tests/sample_header_test.py
@@ -66,4 +66,4 @@ vivamus at augue eget arcu dictum varius.)doc";
 #endif
 
 """
-    
+


### PR DESCRIPTION
Added testing section in README with `--forked` option, as the library doesn't support multiple calls to `extract_all` as of now (tried briefly, but opted for this option instead).

Also added one mini test, which should in future address correct wrapping of lists (bullet, numbered, ...).