### PR TITLE
Make sure output file directory exists before trying to open file for writing.

### DIFF
--- a/pybind11_mkdoc/mkdoc_lib.py
+++ b/pybind11_mkdoc/mkdoc_lib.py
@@ -412,6 +412,7 @@ def mkdoc(args, width, output=None):
 
     if output:
         try:
+            os.makedirs(os.path.dirname(output), exist_ok=True)
             with open(output, 'w') as out_file:
                 write_header(comments, out_file)
         except:


### PR DESCRIPTION
Fixes pybind/pybind11_mkdoc#13