### PR TITLE
Improve robustness on non default environments

### DIFF
--- a/pybind11_mkdoc/mkdoc_lib.py
+++ b/pybind11_mkdoc/mkdoc_lib.py
@@ -280,8 +280,13 @@ def read_args(args):
         if 'LIBCLANG_PATH' in os.environ:
             cindex.Config.set_library_file(os.environ['LIBCLANG_PATH'])
         else:
-            library_file = sorted(glob("/usr/lib/llvm-*/lib/libclang.so.1"), reverse=True)[0]
-            cindex.Config.set_library_file(library_file)
+            library_file_dirs = glob("/usr/lib/llvm-*/lib/libclang.so.1")
+            if len(library_file_dirs) > 0:
+                library_file = sorted(library_file_dirs, reverse=True)[0]
+                cindex.Config.set_library_file(library_file)
+            else:
+                raise FileNotFoundError("Failed to find libclang.so shared object file! "
+                                        "Set the LIBCLANG_PATH environment variable to provide a path to it.")
 
         # clang doesn't find its own base includes by default on Linux,
         # but different distros install them in different paths.

--- a/pybind11_mkdoc/mkdoc_lib.py
+++ b/pybind11_mkdoc/mkdoc_lib.py
@@ -310,7 +310,8 @@ def read_args(args):
                 glob(os.path.join(llvm_dir, 'lib', 'clang', '*')
             ), default=None, key=folder_version)
 
-            parameters.extend(['-isystem', clang_include_dir])
+            if clang_include_dir is not None:
+                parameters.extend(['-isystem', clang_include_dir])
 
         # Add additional C++ include directories
         cpp_dirs = []


### PR DESCRIPTION
This pull request improves the mkdoc_lib on systems where the directory structures do not match the expected default ones by adding more sanity checks.

Fixes pybind/pybind11_mkdoc#15 and pybind/pybind11_mkdoc#16