### PR TITLE
fix output dir creation error when dirname is empty

### DIFF
--- a/pybind11_mkdoc/mkdoc_lib.py
+++ b/pybind11_mkdoc/mkdoc_lib.py
@@ -426,7 +426,7 @@ def mkdoc(args, width, output=None):
 
     if output:
         try:
-            os.makedirs(os.path.dirname(output), exist_ok=True)
+            os.makedirs(os.path.dirname(os.path.abspath(output)), exist_ok=True)
             with open(output, 'w') as out_file:
                 write_header(comments, out_file)
         except:


### PR DESCRIPTION
When just specifying a output filename (i.e. in current working dir) the `os.makedirs(os.path.dirname(output))` command would fail because the dirname is empty.