### PR TITLE
Fix generated pybind11-mkdoc console script

### DIFF
--- a/pybind11_mkdoc/__init__.py
+++ b/pybind11_mkdoc/__init__.py
@@ -12,5 +12,56 @@ from .mkdoc_lib import mkdoc
 
 __version__ = "2.6.1.dev1"
 
-def main(self):
-    return mkdoc(sys.argv[:1])
+def main():
+    mkdoc_out = None
+    mkdoc_help = False
+    mkdoc_args = []
+    docstring_width = None
+
+    i = 1
+    while i < len(sys.argv):
+        arg = sys.argv[i]
+
+        if arg == '-h':
+            mkdoc_help = True
+        elif arg == '-o':
+            mkdoc_out = sys.argv[i + 1]
+            i += 1 # Skip next
+        elif arg.startswith('-o'):
+            mkdoc_out = arg[2:]
+        elif arg == '-w':
+            docstring_width = int(sys.argv[i + 1])
+            i += 1 # Skip next
+        elif arg.startswith('-w'):
+            docstring_width = int(arg[2:])
+        elif arg == '-I':
+            # Concatenate include directive and path
+            mkdoc_args.append(arg + sys.argv[i + 1])
+            i += 1 # Skip next
+        else:
+            mkdoc_args.append(arg)
+        i += 1
+
+    if len(mkdoc_args) == 0 or mkdoc_help:
+        print("""Syntax: python -m pybind11_mkdoc [options] .. list of headers files ..
+
+This tool processes a sequence of C/C++ headers and extracts comments for use
+in pybind11 binding code.
+
+Options:
+
+  -h                Display this help text
+
+  -o <filename>     Write to the specified filename (default: use stdout)
+
+  -w <width>        Specify docstring width before wrapping
+
+  -I <path>         Specify an include directory
+
+  -Dkey=value       Specify a compiler definition
+
+(Other compiler flags that Clang understands can also be supplied)""")
+    else:
+        mkdoc(mkdoc_args, docstring_width, mkdoc_out)
+
+    return 0

--- a/pybind11_mkdoc/__main__.py
+++ b/pybind11_mkdoc/__main__.py
@@ -1,55 +1,5 @@
-from .mkdoc_lib import mkdoc
-import sys
-
 
 if __name__ == "__main__":
-    mkdoc_out = None
-    mkdoc_help = False
-    mkdoc_args = []
-    docstring_width = None
+    from . import main
+    main()
 
-    i = 1
-    while i < len(sys.argv):
-        arg = sys.argv[i]
-
-        if arg == '-h':
-            mkdoc_help = True
-        elif arg == '-o':
-            mkdoc_out = sys.argv[i + 1]
-            i += 1 # Skip next
-        elif arg.startswith('-o'):
-            mkdoc_out = arg[2:]
-        elif arg == '-w':
-            docstring_width = int(sys.argv[i + 1])
-            i += 1 # Skip next
-        elif arg.startswith('-w'):
-            docstring_width = int(arg[2:])
-        elif arg == '-I':
-            # Concatenate include directive and path
-            mkdoc_args.append(arg + sys.argv[i + 1])
-            i += 1 # Skip next
-        else:
-            mkdoc_args.append(arg)
-        i += 1
-
-    if len(mkdoc_args) == 0 or mkdoc_help:
-        print("""Syntax: python -m pybind11_mkdoc [options] .. list of headers files ..
-
-This tool processes a sequence of C/C++ headers and extracts comments for use
-in pybind11 binding code.
-
-Options:
-
-  -h                Display this help text
-
-  -o <filename>     Write to the specified filename (default: use stdout)
-
-  -w <width>        Specify docstring width before wrapping
-
-  -I <path>         Specify an include directory
-
-  -Dkey=value       Specify a compiler definition
-
-(Other compiler flags that Clang understands can also be supplied)""")
-    else:
-        mkdoc(mkdoc_args, docstring_width, mkdoc_out)


### PR DESCRIPTION
The console script generated by the pyproject.toml:[tool.flit.scripts] config would not work. First of all, because the `main()` implementation in __init__.py expects a `self` argument but also the because it wasn't implemented correctly.
Moving the actual `__main__` implementation solves this.