### PR TITLE
Windows support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,8 @@ name: CI
 on:
   pull_request:
   push:
-    branches: master
+    branches: 
+    - master
     tags:
     - 'v*'
 
@@ -14,6 +15,8 @@ jobs:
       matrix:
         python-version:
         - 3.6
+        - 3.7
+        - 3.8
         - 3.9
         runs-on:
         - ubuntu-latest
@@ -31,8 +34,32 @@ jobs:
 
     - name: Test package
       run: python -m pytest --forked
+      
+  checks_windows:
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version:
+        - 3.8
+        - 3.9
+        runs-on:
+        - windows-latest
+    runs-on: ${{ matrix.runs-on }}
+    name: Test • 🐍 ${{ matrix.python-version }} • ${{matrix.runs-on}}
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
 
+    - name: Install package
+      run: python -m pip install .[test]
 
+    - name: Test package
+      env:
+        LIBCLANG_PATH: C:\msys64\mingw64\bin\libclang.dll
+      run: python -m pytest -n2
+  
   dist:
     runs-on: ubuntu-latest
     name: Build distribution

--- a/README.md
+++ b/README.md
@@ -76,7 +76,8 @@ py::class_<MyClass>(m, "MyClass", DOC(MyClass))
 
 ## Limitations
 
-This tool supports Linux, macOS and Windows. It requires Clang/LLVM to be installed.
+This tool supports Linux and macOS for Python versions 3.6 to 3.9. On Windows you at least need Python version 3.8.
+Also, it requires Clang/LLVM to be installed.
 
 
 ## Testing
@@ -93,5 +94,5 @@ python3 -m pip install .
 
 And execute the tests (forked)
 ```
-python3 -m pip pytest --forked
+python3 -m pytest --forked
 ```

--- a/README.md
+++ b/README.md
@@ -76,8 +76,7 @@ py::class_<MyClass>(m, "MyClass", DOC(MyClass))
 
 ## Limitations
 
-This tool supports Linux and macOS and requires Clang/LLVM to be installed. It
-has never been used on Windows and will likely require adaptations.
+This tool supports Linux, macOS and Windows. It requires Clang/LLVM to be installed.
 
 
 ## Testing

--- a/pybind11_mkdoc/mkdoc_lib.py
+++ b/pybind11_mkdoc/mkdoc_lib.py
@@ -275,16 +275,17 @@ def read_args(args):
             parameters.append('-isysroot')
             parameters.append(sysroot_dir)
     elif platform.system() == 'Windows':
-        library_file = ctypes.util.find_library("libclang.dll")
-        if library_file is not None:
-            cindex.Config.set_library_file(library_file)
-        elif 'LIBCLANG_PATH' in os.environ:
+        if 'LIBCLANG_PATH' in os.environ:
             library_file = os.environ['LIBCLANG_PATH']
             if os.path.isfile(library_file):
                 cindex.Config.set_library_file(library_file)
             else:
                 raise FileNotFoundError("Failed to find libclang.dll! "
                                         "Set the LIBCLANG_PATH environment variable to provide a path to it.")
+        else:
+            library_file = ctypes.util.find_library('libclang.dll')
+            if library_file is not None:
+                cindex.Config.set_library_file(library_file)
     elif platform.system() == 'Linux':
         # cython.util.find_library does not find `libclang` for all clang
         # versions and distributions. LLVM switched to a monolithical setup

--- a/pybind11_mkdoc/mkdoc_lib.py
+++ b/pybind11_mkdoc/mkdoc_lib.py
@@ -272,6 +272,14 @@ def read_args(args):
             sysroot_dir = os.path.join(sdk_dir, next(os.walk(sdk_dir))[1][0])
             parameters.append('-isysroot')
             parameters.append(sysroot_dir)
+    elif platform.system() == 'Windows':
+        if 'LIBCLANG_PATH' in os.environ:
+            library_file = os.environ['LIBCLANG_PATH']
+            if os.path.isfile(library_file):
+                cindex.Config.set_library_file(library_file)
+            else:
+                raise FileNotFoundError("Failed to find libclang.dll! "
+                                        "Set the LIBCLANG_PATH environment variable to provide a path to it.")
     elif platform.system() == 'Linux':
         # cython.util.find_library does not find `libclang` for all clang
         # versions and distributions. LLVM switched to a monolithical setup

--- a/pybind11_mkdoc/mkdoc_lib.py
+++ b/pybind11_mkdoc/mkdoc_lib.py
@@ -6,12 +6,13 @@
 #  Extract documentation from C++ header files to use it in Python bindings
 #
 
-import ctypes
 import os
 import sys
 import platform
 import re
 import textwrap
+
+import ctypes.util
 
 from clang import cindex
 from clang.cindex import CursorKind

--- a/pybind11_mkdoc/mkdoc_lib.py
+++ b/pybind11_mkdoc/mkdoc_lib.py
@@ -6,6 +6,7 @@
 #  Extract documentation from C++ header files to use it in Python bindings
 #
 
+import ctypes
 import os
 import sys
 import platform
@@ -273,7 +274,10 @@ def read_args(args):
             parameters.append('-isysroot')
             parameters.append(sysroot_dir)
     elif platform.system() == 'Windows':
-        if 'LIBCLANG_PATH' in os.environ:
+        library_file = ctypes.util.find_library("libclang.dll")
+        if library_file is not None:
+            cindex.Config.set_library_file(library_file)
+        elif 'LIBCLANG_PATH' in os.environ:
             library_file = os.environ['LIBCLANG_PATH']
             if os.path.isfile(library_file):
                 cindex.Config.set_library_file(library_file)


### PR DESCRIPTION
This PR adds Windows support for `pybind11_mkdoc`.

It should work out of the box, if `libclang.dll` can be found in a `PATH` directory, otherwise by setting the `LIBCLANG_PATH` variable.