### PR TITLE
Various Doxygen improvements

### DIFF
--- a/pybind11_mkdoc/mkdoc_lib.py
+++ b/pybind11_mkdoc/mkdoc_lib.py
@@ -126,6 +126,9 @@ def process_comment(comment):
     s = re.sub(r'[\\@]tparam%s?\s+%s' % (param_group, cpp_group),
                r'\n\n$Template parameter ``\2``:\n\n', s)
 
+    # Remove class and struct tags
+    s = re.sub(r'[\\@](class|struct)\s+.*', '', s)
+
     for in_, out_ in {
         'returns': 'Returns',
         'return': 'Returns',

--- a/pybind11_mkdoc/mkdoc_lib.py
+++ b/pybind11_mkdoc/mkdoc_lib.py
@@ -92,13 +92,13 @@ def process_comment(comment):
     leading_spaces = float('inf')
     for s in comment.expandtabs(tabsize=4).splitlines():
         s = s.strip()
-        if s.startswith('/*'):
-            s = s[2:].lstrip('*')
-        elif s.endswith('*/'):
+        if s.endswith('*/'):
             s = s[:-2].rstrip('*')
-        elif s.startswith('///'):
-            s = s[3:]
-        if s.startswith('*'):
+        if s.startswith('/*'):
+            s = s[2:].lstrip('*!<')
+        elif s.startswith('//'):
+            s = s[2:].lstrip('/!<')
+        elif s.startswith('*'):
             s = s[1:]
         if len(s) > 0:
             leading_spaces = min(leading_spaces, len(s) - len(s.lstrip()))

--- a/pybind11_mkdoc/mkdoc_lib.py
+++ b/pybind11_mkdoc/mkdoc_lib.py
@@ -115,7 +115,7 @@ def process_comment(comment):
     param_group = r'([\[\w:,\]]+)'
 
     s = result
-    s = re.sub(r'[\\@]c\s+%s' % cpp_group, r'``\1``', s)
+    s = re.sub(r'[\\@][cp]\s+%s' % cpp_group, r'``\1``', s)
     s = re.sub(r'[\\@]a\s+%s' % cpp_group, r'*\1*', s)
     s = re.sub(r'[\\@]e\s+%s' % cpp_group, r'*\1*', s)
     s = re.sub(r'[\\@]em\s+%s' % cpp_group, r'*\1*', s)


### PR DESCRIPTION
Many Doxygen tags and trailing `*/` were left in the docstrings, for example

```
const AddrLen addressLength; /*!< \brief I2C address width */
```

was translated as

```
static const char *__doc_IIC_addressLength = R"doc(!< I2C address width */)doc";
```

