### PR TITLE
Allow special characters in one-word markup

### DIFF
--- a/pybind11_mkdoc/mkdoc_lib.py
+++ b/pybind11_mkdoc/mkdoc_lib.py
@@ -111,7 +111,7 @@ def process_comment(comment):
         result = result2
 
     # Doxygen tags
-    cpp_group = r'([\w:]+)'
+    cpp_group = r'([^\s]+)'
     param_group = r'([\[\w:,\]]+)'
 
     s = result


### PR DESCRIPTION
This fixes parsing of e.g. `You can set @c my_var=value`, which renders in doxygen as `my_var=my_value` (as code).
Before the change, pybind11_mkdoc renders this into

    ``my_var``=value

After the change, it renders correctly as

    ``my_var=value``