### PR TITLE
README.md: use HTTPS for pip install

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ be referenced to generate docstrings in pybind11 binding code.
 To install the latest development version:
 
 ```bash
-python -m pip install git+git://github.com/pybind/pybind11_mkdoc.git@master
+python -m pip install git+https://github.com/pybind/pybind11_mkdoc.git@master
 ```
 
 ## Usage


### PR DESCRIPTION
Support for the unencrypted Git protocol was dropped by GitHub: https://github.blog/2021-09-01-improving-git-protocol-security-github/