### PR TITLE
Switch to libclang

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ classifiers = [
   "Operating System :: POSIX",
   "Operating System :: MacOS"
 ]
-requires = ["clang"]
+requires = ["libclang"]
 requires-python = ">=3.6"
 
 [tool.flit.scripts]


### PR DESCRIPTION
A newer package provigind the python libclang bindings is available, called "libclang". Unlike "clang", this package ships the  libclang library, removing the dependency from the system's one. This dependency is particularly frustrating as it requires not only the presence of libclang on the system, but also a specific version of it, requiring things like `pip3 install clang==14` where the version depends on the distro and distro's version.

The "libclang" library is identical to the "clang" one, the only difference being a pre-set `index.Config.library_path`, set to the package's library.

This PR adds support to it, detecting if `index.Config.library_path` is set (and so, if "libclang" is being used) and leaving it as it is unless overridden by the environment variables. With this, pybind11_mkdoc works out-of-the-box.

The only issue are the system's headers, not shipped within "libclang" (see sighingnow/libclang#40) which cause some error messages on the stderr like

```
/usr/include/unistd.h:226:10: fatal error: 'stddef.h' file not found
```

but the docstrings generation successfully completes anyways.

As a side effect, this fixes pybind11_mkdoc on Arch Linux, as it currently can not find libclang.so (installed under `/usr/lib/`, while [pybind11_mkdoc searches it under `/usr/lib/llvm{version_number}/`](https://github.com/pybind/pybind11_mkdoc/blob/42fbf377824185e255b06d68fa70f4efcd569e2d/pybind11_mkdoc/mkdoc_lib.py#L293-L295)).

**Tested only on Linux.**