### PR TITLE
Support doxygen `@exception` command

### DIFF
--- a/pybind11_mkdoc/mkdoc_lib.py
+++ b/pybind11_mkdoc/mkdoc_lib.py
@@ -140,6 +140,7 @@ def process_comment(comment):
         'sa': 'See also',
         'see': 'See also',
         'extends': 'Extends',
+        'exception': 'Throws',
         'throws': 'Throws',
         'throw': 'Throws'
     }.items():


### PR DESCRIPTION
Add support for the doxygen `@exception` command.

The `@throws` and `@throw` commands are synonyms of `@exception`, but are already supported by pybind11_mkdoc.

See https://www.doxygen.nl/manual/commands.html#cmdexception