### PR TITLE
Add doxygen command note and fix warning

### DIFF
--- a/pybind11_mkdoc/mkdoc_lib.py
+++ b/pybind11_mkdoc/mkdoc_lib.py
@@ -153,7 +153,9 @@ def process_comment(comment):
     s = re.sub(r'[\\@]code\s?(.*?)\s?[\\@]endcode',
                r"```\n\1\n```\n", s, flags=re.DOTALL)
     s = re.sub(r'[\\@]warning\s?(.*?)\s?\n\n',
-               r'$.. warning::\n\n\1\n\n', s, flags=re.DOTALL)
+               r'\n\n$.. warning::\n\n\1\n\n', s, flags=re.DOTALL)
+    s = re.sub(r'[\\@]note\s?(.*?)\s?\n\n',
+               r'\n\n$.. note::\n\n\1\n\n', s, flags=re.DOTALL)
     # Deprecated expects a version number for reST and not for Doxygen. Here the first word of the
     # doxygen directives is assumed to correspond to the version number
     s = re.sub(r'[\\@]deprecated\s(.*?)\s?(.*?)\s?\n\n',


### PR DESCRIPTION
This PR adds the doxygen `@note` command and fix the `@warning` one. 

Test docstring: 

```c++
/**
 * This is a method to test docstring parsing with pybind11-mkdoc
 * @note Test pybind11-mkdoc
 * @warning This method has no implementation
 * @param a     roll angle
 * @param b     value b
 */
void myMethod(int a, int b);
```

Without the patch:

```rst
static const char *__doc_myMethod =
R"doc(This is a method to test docstring parsing with pybind11-mkdoc @note
Test pybind11-mkdoc $.. warning::

This method has no implementation

Parameter ``a``:
    roll angle

Parameter ``b``:
    value b)doc";
```

With the patch:

```rst
static const char *__doc_myMethod =
R"doc(This is a method to test docstring parsing with pybind11-mkdoc

.. note::
    Test pybind11-mkdoc

.. warning::
    This method has no implementation

Parameter ``a``:
    roll angle

Parameter ``b``:
    value b)doc";
```

Maybe, other commands such as `@deprecated`, `@todo`, `@code` or `@since` should be fixed also.