### PR TITLE
chore: modernize pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,14 +1,19 @@
 [build-system]
-requires = ["flit_core >=2,<4"]
+requires = ["flit_core>=3.9"]
 build-backend = "flit_core.buildapi"
 
-[tool.flit.metadata]
-module = "pybind11_mkdoc"
-author = "Wenzel Jakob"
-author-email = "wenzel.jakob@epfl.ch"
-home-page = "https://github.com/pybind/pybind11_mkdoc"
+[project]
+name = "pybind11_mkdoc"
+description = "Generate documentation bindings for pybind11 modules."
+readme = "README.md"
+requires-python = ">=3.9"
+license = "MIT"
+authors = [
+    { name = "Wenzel Jakob", email = "wenzel.jakob@epfl.ch" }
+]
+urls.homepage = "https://github.com/pybind/pybind11_mkdoc"
+dependencies = ["clang"]
 classifiers = [
-  "License :: OSI Approved :: MIT License",
   "Development Status :: 3 - Alpha",
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
@@ -20,16 +25,18 @@ classifiers = [
   "Operating System :: POSIX",
   "Operating System :: MacOS"
 ]
-requires = ["clang"]
-requires-python = ">=3.9"
+dynamic = ["version"]
 
-[tool.flit.scripts]
-pybind11-mkdoc = "pybind11_mkdoc:main"
-
-[tool.flit.metadata.requires-extra]
+[project.optional-dependencies]
 test = [
     "pytest",
     "pybind11",
-    "pytest-forked"
+    "pytest-forked",
 ]
 
+[project.scripts]
+pybind11-mkdoc = "pybind11_mkdoc:main"
+
+
+[tool.flit.sdist]
+include = ["tests/**/*.py", "tests/**/*.h", ".gitignore"]


### PR DESCRIPTION
Used `uvx check-dist` to find missing files in the SDist (common flit-core problem). Used ChatGPT to do the conversion (messed up by inventing a `homepage =`, but otherwise did well).