### PR TITLE
docs: remove explicit default branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ be referenced to generate docstrings in pybind11 binding code.
 To install the latest development version:
 
 ```bash
-python -m pip install git+https://github.com/pybind/pybind11_mkdoc.git@master
+python -m pip install git+https://github.com/pybind/pybind11_mkdoc.git
 ```
 
 ## Usage


### PR DESCRIPTION
No reason to hardcode the branch name here, especially if we ever want to change it to main, for example.