### PR TITLE
ci: bump setup-uv to maintained tag scheme

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     name: Format
     steps:
     - uses: actions/checkout@v6
-    - uses: astral-sh/setup-uv@v7
+    - uses: astral-sh/setup-uv@v8.0.0
     - run: uvx hatch fmt
 
   checks:
@@ -35,7 +35,7 @@ jobs:
     - uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
-    - uses: astral-sh/setup-uv@v7
+    - uses: astral-sh/setup-uv@v8.0.0
 
     - name: Test package
       run: uv run --with "clang<19" --group test pytest --forked


### PR DESCRIPTION
The old vX tags have been dropped to (force) (usually) better security practices. Dependabot will not update, however, leaving this v7 tag forever. Manually updating now.

See https://github.com/astral-sh/setup-uv/issues/830

Committed via https://github.com/asottile/all-repos