### PR TITLE
ci: add cd.yml for trusted publishing

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,0 +1,50 @@
+name: CD
+
+on:
+  workflow_dispatch:
+  release:
+    types:
+    - published
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions: {}
+
+jobs:
+  dist:
+    runs-on: ubuntu-latest
+    name: Build distribution
+    steps:
+    - uses: actions/checkout@v7
+      with:
+        fetch-depth: 0
+        persist-credentials: false
+    - uses: hynek/build-and-inspect-python-package@v2.18.0
+
+  publish:
+    needs: [dist]
+    runs-on: ubuntu-latest
+    name: Publish to PyPI
+    if: github.event_name == 'release' && github.event.action == 'published'
+    environment:
+      name: pypi
+      url: https://pypi.org/p/pybind11_mkdoc
+    permissions:
+      id-token: write  # Needed for PyPI trusted publishing and attestations
+      attestations: write  # Needed for artifact attestation
+    steps:
+    - uses: actions/download-artifact@v8
+      with:
+        name: Packages
+        path: dist
+
+    - name: Generate artifact attestation for sdist and wheel
+      uses: actions/attest-build-provenance@v4.1.1
+      with:
+        subject-path: "dist/*"
+
+    - uses: pypa/gh-action-pypi-publish@v1.14.1
+      with:
+        attestations: true

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -19,7 +19,6 @@ jobs:
     steps:
     - uses: actions/checkout@v7
       with:
-        fetch-depth: 0
         persist-credentials: false
     - uses: hynek/build-and-inspect-python-package@v2.18.0
 
@@ -46,5 +45,3 @@ jobs:
         subject-path: "dist/*"
 
     - uses: pypa/gh-action-pypi-publish@v1.14.1
-      with:
-        attestations: true

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -20,7 +20,7 @@ jobs:
     - uses: actions/checkout@v7
       with:
         persist-credentials: false
-    - uses: hynek/build-and-inspect-python-package@v2.18.0
+    - uses: hynek/build-and-inspect-python-package@v3.0.1
 
   publish:
     needs: [dist]
@@ -44,4 +44,4 @@ jobs:
       with:
         subject-path: "dist/*"
 
-    - uses: pypa/gh-action-pypi-publish@v1.14.1
+    - uses: pypa/gh-action-pypi-publish@v1.14.2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,4 +75,4 @@ jobs:
     name: Build distribution
     steps:
     - uses: actions/checkout@v7
-    - uses: hynek/build-and-inspect-python-package@v2.18.0
+    - uses: hynek/build-and-inspect-python-package@v3.0.1


### PR DESCRIPTION
I Claupied this from some of my other repos (pybind11, scikit-build-core, and repo-review).

:robot: _AI text below_ :robot:

Adds a CD workflow that publishes to PyPI on a published release, with `workflow_dispatch` for a dry run of the build.

- `dist` builds and inspects the sdist and wheel with `hynek/build-and-inspect-python-package`.
- `publish` runs only for published releases in the `pypi` environment, and uses trusted publishing with build provenance attestations.

Before the first release, PyPI needs a trusted publisher for `pybind11_mkdoc` (workflow `cd.yml`, environment `pypi`), and the repository needs a `pypi` environment.