### PR TITLE
feat!: default to -std=c++17

### DIFF
--- a/pybind11_mkdoc/mkdoc_lib.py
+++ b/pybind11_mkdoc/mkdoc_lib.py
@@ -566,7 +566,7 @@ def read_args(args):
     if "-x" not in args:
         parameters.extend(["-x", "c++"])
     if not any(it.startswith("-std=") for it in args):
-        parameters.append("-std=c++11")
+        parameters.append("-std=c++17")
     parameters.append("-Wno-pragma-once-outside-header")
 
     if platform.system() == "Darwin":

--- a/tests/read_args_test.py
+++ b/tests/read_args_test.py
@@ -1,0 +1,13 @@
+from pybind11_mkdoc.mkdoc_lib import read_args
+
+
+def test_default_std():
+    parameters, filenames = read_args(["sample.h"])
+    assert "-std=c++17" in parameters
+    assert filenames == ["sample.h"]
+
+
+def test_explicit_std_wins():
+    parameters, _ = read_args(["-std=c++11", "sample.h"])
+    assert "-std=c++11" in parameters
+    assert "-std=c++17" not in parameters


### PR DESCRIPTION
:robot: _AI text below_ :robot:

The default C++ standard used when no `-std=` flag is given moves from c++11 to c++17, so modern headers parse correctly. An explicit `-std=` from the caller still wins.

The clang version is left to the user; `pyproject.toml` keeps the unpinned `clang` dependency and CI keeps its own `clang<19` constraint.