### PR TITLE
fix: keep explicit empty value in -D definitions

### DIFF
--- a/pybind11_mkdoc/__init__.py
+++ b/pybind11_mkdoc/__init__.py
@@ -6,7 +6,7 @@ This is a package for building pybind11 docstrings from C++ header comments.
 
 import argparse
 import os
-import re
+import sys
 from pathlib import Path
 
 from pybind11_mkdoc.mkdoc_lib import mkdoc
@@ -34,7 +34,7 @@ def _append_include_dir(args: list, include_dir: str, *, verbose: bool = True):
     if os.path.isdir(include_dir):
         args.append(f"-I{include_dir}")
     elif verbose:
-        pass
+        print(f"Include directory '{include_dir}' does not exist!", file=sys.stderr)  # noqa: T201
 
 
 def _append_definition(args: list, definition: str):
@@ -42,7 +42,8 @@ def _append_definition(args: list, definition: str):
     Add a compiler definition to an argument list.
 
     The definition is expected to be given in the format '<macro>=<value>',
-    which will define <macro> to <value> (or 1 if <value> is omitted).
+    which will define <macro> to <value> (or 1 if the '=<value>' part is
+    omitted). An explicit empty value ('<macro>=') defines <macro> to nothing.
 
     Parameters
     ----------
@@ -52,26 +53,12 @@ def _append_definition(args: list, definition: str):
 
     definition: str
         The definition to append.
-
-    verbose: bool
-        Whether to print a warning for invalid definition strings.
     """
 
-    try:
-        macro, _, value = definition.partition("=")
-        macro = macro.strip()
-        value = value.strip() if value else "1"
+    macro, sep, value = definition.partition("=")
+    value = value.strip() if sep else "1"
 
-        args.append(f"-D{macro}={value}")
-    except ValueError:
-        # most likely means there was no '=' given
-        # check if argument is valid identifier
-        if re.search(r"^[A-Za-z_][A-Za-z0-9_]*", definition):
-            args.append(f"-D{definition}")
-        else:
-            pass
-    except Exception:
-        pass
+    args.append(f"-D{macro.strip()}={value}")
 
 
 def get_cmake_dir() -> Path:
@@ -142,7 +129,7 @@ def main():
 
     parser.add_argument("header", type=str, nargs="+", help="A header file to process.")
 
-    [parsed_args, unparsed_args] = parser.parse_known_args()
+    parsed_args, unparsed_args = parser.parse_known_args()
 
     mkdoc_args = []
     mkdoc_out = parsed_args.output
@@ -165,7 +152,7 @@ def main():
             # append argument as is and hope for the best
             mkdoc_args.append(arg)
 
-    mkdoc_args.extend(header for header in parsed_args.header)
+    mkdoc_args.extend(parsed_args.header)
 
     mkdoc(mkdoc_args, docstring_width, mkdoc_out)
 

--- a/pybind11_mkdoc/mkdoc_lib.py
+++ b/pybind11_mkdoc/mkdoc_lib.py
@@ -744,7 +744,7 @@ def write_header(comments, out_file=sys.stdout):
 def mkdoc(args, width, output=None):
     if width is not None:
         global docstring_width
-        docstring_width = int(width)
+        docstring_width = width
     comments = extract_all(args)
 
     if output:

--- a/tests/cli_test.py
+++ b/tests/cli_test.py
@@ -4,6 +4,8 @@ from pathlib import Path
 
 import pytest
 
+from pybind11_mkdoc import _append_definition
+
 DIR = Path(__file__).resolve().parent
 
 with open(DIR / "sample_header_docs" / "sample_header_truth.h") as f:
@@ -25,6 +27,22 @@ def test_simple_header_cli(tmp_path: Path, name: str) -> None:
     res = tf.read_text(encoding="utf-8")
 
     assert res == expected
+
+
+@pytest.mark.parametrize(
+    ("definition", "expected_arg"),
+    [
+        ("FOO", "-DFOO=1"),
+        ("FOO=", "-DFOO="),
+        ("FOO=2", "-DFOO=2"),
+        (" FOO = 2 ", "-DFOO=2"),
+    ],
+)
+def test_append_definition(definition: str, expected_arg: str) -> None:
+    args: list[str] = []
+    _append_definition(args, definition)
+
+    assert args == [expected_arg]
 
 
 def test_parse_failure_sets_exit_code(tmp_path: Path) -> None:


### PR DESCRIPTION
This seems oddly intentional; the new version does seem better, but was there a reason for the old one?

:robot: _AI text below_ :robot:

Addresses finding 7 and the `__init__.py` simplifications from the review in #59.

- `-DFOO=` (explicit empty value) kept an empty value, as clang does. Before, it became `FOO=1`. A bare `-DFOO` still becomes `FOO=1`.
- `_append_definition`: removed the two unreachable `except` blocks (`str.partition` does not raise `ValueError`) and simplified the function.
- `_append_include_dir`: prints the warning for a missing directory that the docstring promises, instead of doing nothing.
- `main`: plain tuple unpacking for `parse_known_args`, `extend(parsed_args.header)`, and no more redundant `int(width)` (argparse uses `type=int`).

A parametrized regression test for `_append_definition` is included.
