### PR TITLE
fix(cmake): make EXTRA_ARGS a multi-value argument

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -1,12 +1,22 @@
 cmake_minimum_required(VERSION 3.25...4.3)
-project(pybind11_mkdoc)
+
+# Read the version from the Python package; project() accepts numeric components only,
+# so any dev/pre-release suffix is dropped.
+file(STRINGS "${CMAKE_CURRENT_SOURCE_DIR}/../pybind11_mkdoc/__init__.py" version_line
+    REGEX "^__version__ *= *[\"']"
+)
+if(NOT version_line MATCHES "([0-9]+(\\.[0-9]+)*)")
+    message(FATAL_ERROR "Could not read __version__ from pybind11_mkdoc/__init__.py")
+endif()
+
+project(pybind11_mkdoc VERSION "${CMAKE_MATCH_1}")
 
 include(CMakePackageConfigHelpers)
 
 # Generate version file
 write_basic_package_version_file(
     "${CMAKE_CURRENT_BINARY_DIR}/pybind11_mkdocConfigVersion.cmake"
-    VERSION 2.6.2
+    VERSION ${PROJECT_VERSION}
     COMPATIBILITY SameMajorVersion
 )
 

--- a/cmake/pybind11_mkdoc_functions.cmake
+++ b/cmake/pybind11_mkdoc_functions.cmake
@@ -11,7 +11,7 @@
 #             current source directory.
 #
 # The optional parameters are:
-# * EXTRA_ARGS - This string argument will be added verbatim to the pybind11-mkdoc command.
+# * EXTRA_ARGS - A list of arguments that will be added verbatim to the pybind11-mkdoc command.
 #
 # Example usage:
 # pybind11_add_module(my_pybind11_module src/my_pybind11_module.cc)
@@ -24,8 +24,8 @@
 # )
 function (pybind11_mkdoc)
     set(options)
-    set(oneValueArgs OUTPUT PYBIND11_MODULE EXTRA_ARGS)
-    set(multiValueArgs HEADERS)
+    set(oneValueArgs OUTPUT PYBIND11_MODULE)
+    set(multiValueArgs HEADERS EXTRA_ARGS)
     cmake_parse_arguments(PARSE_ARGV 0 arg
         "${options}" "${oneValueArgs}" "${multiValueArgs}"
     )

--- a/pybind11_mkdoc/share/cmake/pybind11_mkdoc/pybind11_mkdoc_functions.cmake
+++ b/pybind11_mkdoc/share/cmake/pybind11_mkdoc/pybind11_mkdoc_functions.cmake
@@ -11,7 +11,7 @@
 #             current source directory.
 #
 # The optional parameters are:
-# * EXTRA_ARGS - This string argument will be added verbatim to the pybind11-mkdoc command.
+# * EXTRA_ARGS - A list of arguments that will be added verbatim to the pybind11-mkdoc command.
 #
 # Example usage:
 # pybind11_add_module(my_pybind11_module src/my_pybind11_module.cc)
@@ -24,8 +24,8 @@
 # )
 function (pybind11_mkdoc)
     set(options)
-    set(oneValueArgs OUTPUT PYBIND11_MODULE EXTRA_ARGS)
-    set(multiValueArgs HEADERS)
+    set(oneValueArgs OUTPUT PYBIND11_MODULE)
+    set(multiValueArgs HEADERS EXTRA_ARGS)
     cmake_parse_arguments(PARSE_ARGV 0 arg
         "${options}" "${oneValueArgs}" "${multiValueArgs}"
     )

--- a/tests/cmake_docs/my_module_docs_extra_truth.h
+++ b/tests/cmake_docs/my_module_docs_extra_truth.h
@@ -64,6 +64,8 @@ Raises:
 
 static const char *mkd_doc_Base_method3 = R"doc(A method that is only included if MY_EXTRA_DEFINE is defined.)doc";
 
+static const char *mkd_doc_Base_method4 = R"doc(A method that is only included if MY_OTHER_DEFINE is defined.)doc";
+
 static const char *mkd_doc_RootLevelSymbol =
 R"doc(Root-level symbol. Magna fermentum iaculis eu non diam phasellus
 vestibulum.)doc";

--- a/tests/cmake_test.py
+++ b/tests/cmake_test.py
@@ -27,7 +27,8 @@ def test_pybind11_mkdoc_cmake_extra_args(tmp_path: Path) -> None:
     # Run pybind11-mkdoc and put the output in a temp file
     build_dir = tmp_path / "build"
     env = os.environ.copy()
-    env["PYBIND11_TEST_EXTRA_ARGS"] = "-DMY_EXTRA_DEFINE=1"
+    # A CMake list, so it reaches the function as two separate arguments
+    env["PYBIND11_TEST_EXTRA_ARGS"] = "-DMY_EXTRA_DEFINE=1;-DMY_OTHER_DEFINE=1"
 
     subprocess.run(
         ["cmake", "-B", build_dir, "-S", DIR / "cmake_docs", f"-DPython_EXECUTABLE={sys.executable}"],

--- a/tests/sample_header_docs/sample_header_2.h
+++ b/tests/sample_header_docs/sample_header_2.h
@@ -45,4 +45,11 @@ class Base {
      */
     void method3();
 #endif
+
+#ifdef MY_OTHER_DEFINE
+    /**
+     * @brief A method that is only included if MY_OTHER_DEFINE is defined.
+     */
+    void method4();
+#endif
 };


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Addresses finding 8 and the version duplication from #59.

`EXTRA_ARGS` in the `pybind11_mkdoc` CMake function was a one-value keyword, so only the first token reached the command and the rest was silently dropped. It is now a multi-value argument, and each element is passed as its own argv entry.

`cmake/CMakeLists.txt` no longer hardcodes the version. It reads `__version__` from `pybind11_mkdoc/__init__.py` and keeps the numeric components only, because `project(VERSION)` does not accept a dev suffix.

The CMake test now passes two extra defines and the sample header has a second guarded method, so both arguments must take effect for the test to pass. The installed copy of the functions file under `pybind11_mkdoc/share/` was regenerated.