### PR TITLE
ci: add Python 3.15 to test matrix and classifiers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,7 @@ jobs:
         - "3.9"
         - "3.12"
         - "3.14"
+        - "3.15"
         runs-on:
         - ubuntu-latest
         - macos-15-intel
@@ -35,6 +36,7 @@ jobs:
     - uses: actions/setup-python@v7
       with:
         python-version: ${{ matrix.python-version }}
+        allow-prereleases: true
     - uses: astral-sh/setup-uv@v9.0.0
 
     - name: Test package

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ classifiers = [
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
   "Programming Language :: Python :: 3.14",
+  "Programming Language :: Python :: 3.15",
   "Topic :: Software Development :: Documentation",
   "Operating System :: POSIX",
   "Operating System :: MacOS"


### PR DESCRIPTION
Part of #68. (the other parts touch more, so should wait till after most of the open PRs are handled).

:robot: _AI text below_ :robot:

Adds Python 3.15 to the CI matrix and the package classifiers. `setup-python` gets `allow-prereleases: true`, which 3.15 needs while it is in beta.